### PR TITLE
Removed if condition on post.excerpt, Causing gallery post not to show

### DIFF
--- a/lib/directives/post/post.html
+++ b/lib/directives/post/post.html
@@ -5,7 +5,7 @@
     <div class="item item-divider item-toolbar">
         <wphc-post-toolbar post="::postCtrl.post" show-share show-bookmark></wphc-post-toolbar>
     </div>
-    <div class="post-content" ng-if="::postCtrl.post.excerpt" bind-and-compile-html="::(postCtrl.post.content.rendered | prepLink | highlight)"></div>
+    <div class="post-content" bind-and-compile-html="::(postCtrl.post.content.rendered | prepLink | highlight)"></div>
 
     <div class="item item-divider item-toolbar">
         <wphc-post-toolbar post="::postCtrl.post" show-share show-bookmark></wphc-post-toolbar>


### PR DESCRIPTION
Example:
```
[gallery link="file" ids="7,8,9"] 
```
with the following gallery post excert will be null.