### PR TITLE
Replace baseUrl http:// with https://

### DIFF
--- a/dist/config.cson
+++ b/dist/config.cson
@@ -1,7 +1,7 @@
 "title": "Your Blog title"
 
 "api":
-    "baseUrl": "http://dev.julienrenaux.fr/wp-json"
+    "baseUrl": "https://dev.julienrenaux.fr/wp-json"
     "timeout": 10000
     "maxAttempt": 3
 


### PR DESCRIPTION
Fix this error on first start : 

```XMLHttpRequest cannot load https://dev.julienrenaux.fr/wp-json/... The 'Access-Control-Allow-Origin' header has a value 'http://null' that is not equal to the supplied origin. Origin 'null' is therefore not allowed access.```