### PR TITLE
Fix typo showing MD file on Github

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -364,6 +364,6 @@ POS_XY
 Programming language auto detection for tech blogs
 
 * ***tabReplace***: a string used to replace TAB characters in indentation.
-* ***useBR***: a flag to generate <br> tags instead of new-line characters in the output, useful when code is marked up using a non-<pre> container.
+* ***useBR***: a flag to generate `<br>` tags instead of new-line characters in the output, useful when code is marked up using a non-`<pre>` container.
 * ***classPrefix***: a string prefix added before class names in the generated markup, used for backwards compatibility with stylesheets.
 * ***languages***: an array of language names and aliases restricting auto detection to only these languages.


### PR DESCRIPTION
Fix a typo that didn't show the `<br>` and `<pre>` tags on Github