### PR TITLE
Open links in a comment in Safari

### DIFF
--- a/lib/templates/directive/comment.html
+++ b/lib/templates/directive/comment.html
@@ -2,7 +2,7 @@
     <ion-item class="item-avatar item-text-wrap comment">
         <img wphc-img-cache ng-src="{{::commentCtrl.comment.author_avatar_urls[96]}}" ng-if="::commentCtrl.comment.author_avatar_urls[96]">
         <h2>{{::commentCtrl.comment.author_name}}</h2>
-        <div class="comment-content" bind-and-compile-html="::commentCtrl.comment.content.rendered"></div>
+        <div class="comment-content" bind-and-compile-html="::(commentCtrl.comment.content.rendered | prepLink)"></div>
         <p class="text-muted" am-time-ago="::commentCtrl.comment.date"></p>
         <wphc-comment ng-if="commentCtrl.comment.children.length" ng-repeat="comment in commentCtrl.comment.children" comment="comment" class="level-{{::comment.level}}"></wphc-comment>
     </ion-item>


### PR DESCRIPTION
Links in a comment open in app and not in Safari / default Browser. Adding prepLink to commentCtrl.comment.content.rendered fix this issue.