### PR TITLE
Disable bouncing when customTabs shows

### DIFF
--- a/src/pages/tabs/tabs.html
+++ b/src/pages/tabs/tabs.html
@@ -4,7 +4,7 @@
   See http://ionicframework.com/docs/v2/components/#navigation for more info on
   Ionic pages and navigation.
 -->
-<ion-content>
+<ion-content no-bounce>
   <ion-tabs
     #tabs
     [mode]="tabsMode"


### PR DESCRIPTION
After ionic v3, when setting deafult page as customTabs, when scroll over page to top or bottom will happen boucing.
insert no-bounce to tabs.html in <ion-content> to <ion-content no-bounce> will disable bouncing if cordova confin.xml not help the feature.

Signed-off-by: isaac <im.isaacjoe@gmail.com>